### PR TITLE
Fixed issue when you have more than 9 host records per line in hosts file

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using Docker.DotNet;
 using Docker.DotNet.Models;
@@ -359,9 +360,15 @@ namespace windows_hosts_writer
             if (string.IsNullOrEmpty(IP))
                 IP = network.IPAddress;
 
-            var allHosts = string.Join(" ", hostNames);
+            var sb = new StringBuilder();
+            for (int i = 0; i < hostNames.Count; i++)
+            {
+                sb.Append($"{IP}\t{hostNames[i]}\t\t#{containerId} by {GetTail()}");
+                if (i != hostNames.Count - 1) // Don't append new line for the last element
+                    sb.Append(Environment.NewLine);
+            }
 
-            return $"{IP}\t{allHosts}\t\t#{containerId} by {GetTail()}";
+            return sb.ToString();
         }
 
         private static readonly object _lockobject = new object();


### PR DESCRIPTION
Hosts records in the hosts file made to be 1 per IP. There is an issue when you add more than 9 records per line. All records on top of 9 are not recognized. Please check: https://superuser.com/a/932113 and test locally.